### PR TITLE
[#113][bugfix] Study Room Deletion and Chat Bugs

### DIFF
--- a/src/components/StudyRoom/StudyRoomChat/ChatFooter.js
+++ b/src/components/StudyRoom/StudyRoomChat/ChatFooter.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import axios from "axios";
+import GetAuthentication from "../../Authentication/Authentification";
 
 export const ChatFooter = () => {
     const [message, setMessage] = useState('');
@@ -7,10 +8,15 @@ export const ChatFooter = () => {
     const handleSendMessage = (e) => {
         const studyRoomId = window.location.href.split("/")[window.location.href.split("/").length - 1];
         e.preventDefault();
-        const email = JSON.parse(localStorage.getItem('email'))
-        axios.post(`${process.env.REACT_APP_BASE_URL}message/send`, {studyRoomID: studyRoomId, email: email, content: message})
-            .then((res) => {console.log(res)})
-        setMessage('');
+        const email = GetAuthentication().email;
+        axios.post(`${process.env.REACT_APP_BASE_URL}message/send`, {
+            studyRoomID: studyRoomId,
+            email: email,
+            content: message
+        })
+            .then(() => {
+                setMessage('');
+            })
     };
     return (
         <div className="chat__footer">

--- a/src/components/StudyRoom/StudyRoomChat/ChatFooter.js
+++ b/src/components/StudyRoom/StudyRoomChat/ChatFooter.js
@@ -6,8 +6,8 @@ export const ChatFooter = () => {
     const [message, setMessage] = useState('');
 
     const handleSendMessage = (e) => {
-        const studyRoomId = window.location.href.split("/")[window.location.href.split("/").length - 1];
         e.preventDefault();
+        const studyRoomId = window.location.href.split("/")[window.location.href.split("/").length - 1];
         const email = GetAuthentication().email;
         axios.post(`${process.env.REACT_APP_BASE_URL}message/send`, {
             studyRoomID: studyRoomId,

--- a/src/components/StudyRoom/StudyRoomChat/ChatFooter.js
+++ b/src/components/StudyRoom/StudyRoomChat/ChatFooter.js
@@ -7,8 +7,8 @@ export const ChatFooter = () => {
     const handleSendMessage = (e) => {
         const studyRoomId = window.location.href.split("/")[window.location.href.split("/").length - 1];
         e.preventDefault();
-        const email = localStorage.getItem('email')
-        axios.post(`${process.env.REACT_APP_BASE_URL}message/send`, {studyRoomID: studyRoomId, email    : email, content: message})
+        const email = JSON.parse(localStorage.getItem('email'))
+        axios.post(`${process.env.REACT_APP_BASE_URL}message/send`, {studyRoomID: studyRoomId, email: email, content: message})
             .then((res) => {console.log(res)})
         setMessage('');
     };

--- a/src/components/StudyRoom/StudyRoomChat/StudyRoomChat.js
+++ b/src/components/StudyRoom/StudyRoomChat/StudyRoomChat.js
@@ -53,8 +53,8 @@ export function GetStudyRoomChat(){
         );
 
     function isMyMessage(message) {
-        const sender = JSON.parse(message.email);
-        return userEmail.current == `"${sender}"`;
+        const sender = message.email;
+        return userEmail.current === `"${sender}"`;
     }
 
     const MessagesBubbles = () => (React.useMemo(() => {
@@ -82,4 +82,4 @@ export function GetStudyRoomChat(){
     }, [messages]));
 
     return <MessagesBubbles />
-};
+}

--- a/src/components/StudyRoom/StudyRoomChat/StudyRoomChat.js
+++ b/src/components/StudyRoom/StudyRoomChat/StudyRoomChat.js
@@ -3,6 +3,7 @@ import { ChatMessagesCard } from '../../CustomMUIComponents/CustomCards';
 import Grid from "@mui/material/Grid";
 import { socket } from './Sockets';
 import axios from "axios";
+import GetAuthentication from "../../Authentication/Authentification";
 
 export function GetStudyRoomChat(){
 
@@ -10,7 +11,7 @@ export function GetStudyRoomChat(){
     const [messages, setMessages] = React.useState([]);
     const [messageCount, setMessageCount] = React.useState(0)
     React.useEffect(() => {
-        userEmail.current = localStorage.getItem("email");
+        userEmail.current = GetAuthentication().email;
         fetchMessages();
         socket.on("newMessage", listener)
         return () => {
@@ -26,7 +27,6 @@ export function GetStudyRoomChat(){
         const studyRoomId = window.location.href.split("/")[window.location.href.split("/").length - 1];
         axios.get(`${process.env.REACT_APP_BASE_URL}message/bulk/${studyRoomId}/100`)
             .then(res => {
-                console.log(res.data)
                 const messageFromRoom = res.data;
                 const messageReverse = messageFromRoom.reverse();
                 setMessages(messageReverse);
@@ -54,7 +54,7 @@ export function GetStudyRoomChat(){
 
     function isMyMessage(message) {
         const sender = message.email;
-        return userEmail.current === `"${sender}"`;
+        return userEmail.current === `${sender}`;
     }
 
     const MessagesBubbles = () => (React.useMemo(() => {

--- a/src/components/StudyRoom/StudyRoomChat/StudyRoomChat.js
+++ b/src/components/StudyRoom/StudyRoomChat/StudyRoomChat.js
@@ -53,8 +53,7 @@ export function GetStudyRoomChat(){
         );
 
     function isMyMessage(message) {
-        const sender = message.email;
-        return userEmail.current === `${sender}`;
+        return userEmail.current === message.email;
     }
 
     const MessagesBubbles = () => (React.useMemo(() => {

--- a/src/components/StudyRoom/StudyRoomSettings.js
+++ b/src/components/StudyRoom/StudyRoomSettings.js
@@ -54,8 +54,8 @@ export default function StudyRoomSettings() {
     }
 
     //deletes the room in db
-    function handleDelete(e){
-        axios.post(`${process.env.REACT_APP_BASE_URL}room/delete`,{email:roomData.owner, studyRoomID:roomData.studyRoomID})
+    function handleDelete(){
+        axios.delete(`${process.env.REACT_APP_BASE_URL}room`, {data: {email: roomData.owner, studyRoomID: roomData.studyRoomID}})
             .then(() => {
                 navigate("/study-room-home");
             })


### PR DESCRIPTION
This issue is concerned with the following Study Room bugs:
- sending chat messages fails
- deleting a study room fails

Causes:
- sending chat messages make a request with a user email that is wrapped in double quotes, causing database related backend function to not find the user in the database
- deleting a study room sends a request with incorrect type (`post` request instead of a `delete` request), incorrect body structure (body was structured for `post` requests, not `delete` requests), and to the incorrect route. These issues seem to have arisen when the backend was refactored, changing the expected requests by the backend.

Solutions:
- modify chat message requests to send the `email` param without the wrapping double quotes. Subsequently, this also required a small modification to how fetched chat messages are read in the frontend when differentiating between logged in user's messages and other participant messages.
- modify request type, body/API call structure, and route to reflect the expected data by the refactored backend

Resolution: Resolved