### PR TITLE
[#129][BUG] Extra space after Important Academic events on calendar page

### DIFF
--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -219,7 +219,7 @@ export default function CalendarView() {
     const academicEventsDisplay = (
       <> <EventCard justifyContent='auto' width='92vw' height='30px' marginTop='5px' overflow='initial'
         content={<EventHeader content={"Important Academic Events"}/>}  backgroundColor='#E5A712' />
-       <div className="events" style={{overflowY:'auto'}}>
+       <div className="events">
 
                 {academicEvents && academicEvents.map((e, index) => (
                     <>{isSameDate(date, new Date(e.date))?

--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -219,7 +219,7 @@ export default function CalendarView() {
     const academicEventsDisplay = (
       <> <EventCard justifyContent='auto' width='92vw' height='30px' marginTop='5px' overflow='initial'
         content={<EventHeader content={"Important Academic Events"}/>}  backgroundColor='#E5A712' />
-       <div className="events">
+       <div className="events" style={{overflowY:'auto'}}>
 
                 {academicEvents && academicEvents.map((e, index) => (
                     <>{isSameDate(date, new Date(e.date))?
@@ -288,8 +288,12 @@ export default function CalendarView() {
     const calendarPageCards = useMemo(() => (
         <React.Fragment>
             {calendarCard}
-            {eventsDisplay}
-            {academicEventsDisplay}
+            <div style={{paddingBottom:'10px'}}>
+                {eventsDisplay}
+                {academicEventsDisplay}
+            </div>
+
+
         </React.Fragment>
     ), [calendarCard, calendarMonth]);
 
@@ -297,7 +301,7 @@ export default function CalendarView() {
         <React.Fragment>
             <PersistentDrawerLeft />
             <div style={{ paddingTop: '15px' }}>
-                <BackgroundCard width='96vw'  content={calendarPageCards} />
+                <BackgroundCard width='96vw' content={calendarPageCards} />
             </div>
         </React.Fragment>
     );

--- a/src/components/Calendar/calendar.css
+++ b/src/components/Calendar/calendar.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,500,500i,700,700i,900,900i');
 .events {
-    height: 300px;
+    max-height: 300px;
     overflow-y: scroll;
 }
 
@@ -28,7 +28,7 @@
     max-width: 100%;
     background: white;
     border: 1px solid #ffffff;
-    font-family: Roboto;
+    font-family: Roboto,serif;
 
     line-height: 1.125em;
   }


### PR DESCRIPTION
- removed the empty space under Important Academic Event category
- added padding at the bottom
- added generic font name to remove a warning

This closes #129 